### PR TITLE
fix Error: ENOENT: no such file or directory on pathSession

### DIFF
--- a/src/webpack/api/browser.ts
+++ b/src/webpack/api/browser.ts
@@ -30,7 +30,7 @@ export async function initBrowser(Browser: Browser): Promise<Page | boolean> {
           });
         }
       });
-      
+
       Browser.userAgent();
       return wpage;
     } catch {
@@ -64,9 +64,15 @@ export function PathSession(options: CreateOptions) {
     )
   );
 
+  if (!fs.existsSync(pathSession)) {
+    fs.mkdirSync(pathSession, {
+      recursive: true,
+    });
+  }
+
   fs.chmodSync(folderNameToken, '777');
   fs.chmodSync(pathSession, '777');
-  
+
   if (options && options.puppeteerOptions) {
     options.puppeteerOptions.userDataDir = pathSession;
   }


### PR DESCRIPTION
This PR fixing the error: ENOENT: no such file or directory on PathSession.

Error log:
```
Error: ENOENT: no such file or directory, chmod '/Users/chrisk8er/Documents/Projects/new-whatsapp-api/token/krestian'
    at Object.chmodSync (node:fs:1828:3)
    at PathSession (/Users/chrisk8er/Documents/Projects/new-whatsapp-api/node_modules/hydra-bot/dist/webpack/api/browser.js:80:8)
    at initLaunch (/Users/chrisk8er/Documents/Projects/new-whatsapp-api/node_modules/hydra-bot/dist/webpack/api/browser.js:89:5)
    at /Users/chrisk8er/Documents/Projects/new-whatsapp-api/node_modules/hydra-bot/dist/webpack/api/init.js:43:54
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  errno: -2,
  syscall: 'chmod',
  code: 'ENOENT',
  path: '/Users/chrisk8er/Documents/Projects/new-whatsapp-api/token/krestian'
}
```

OS: macOS 10.15.7 
Node: v16.14.0
